### PR TITLE
ci: auto-tag releases on version bump

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,32 @@
+name: Auto-tag on version bump
+
+on:
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version from pyproject.toml
+        id: v
+        run: echo "version=$(grep -Po '(?<=^version = ")[^"]*' pyproject.toml)" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag if missing
+        env:
+          TAG: v${{ steps.v.outputs.version }}
+        run: |
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists — nothing to do."
+            exit 0
+          fi
+          git tag "$TAG"
+          git push origin "$TAG"


### PR DESCRIPTION
## Summary
- Adds [.github/workflows/auto-tag.yml](.github/workflows/auto-tag.yml) — on every push to `main` it reads `[project].version` from `pyproject.toml` and creates+pushes a `v<version>` tag if one doesn't already exist.
- Idempotent: if the tag already exists, the step exits 0 with a no-op log line.
- Unblocks pinning the external deployment config to a semver tag (e.g. `v0.3.1`) instead of a commit SHA.

## How it interacts with the existing Docker workflow
[.github/workflows/docker-publish.yml](.github/workflows/docker-publish.yml) already triggers on both `push: branches: [main]` and `tags: [v*.*.*]`. After this lands, a version-bump merge will run that workflow twice (once per trigger). Both runs publish the same image with the same version tag — wasteful by a few CI minutes but harmless. Tightening that is a future cleanup, out of scope here.

## Test plan
- [ ] Merge to main; confirm Auto-tag workflow runs and creates `v0.3.1` (the version currently on main).
- [ ] Verify `git ls-remote --tags origin` includes `v0.3.1`.
- [ ] On a follow-up version bump, confirm a matching `vX.Y.Z` tag is created and Docker publish runs against it.
- [ ] Re-run the workflow on an unchanged version — confirm the "Tag already exists" path exits 0.

Generated with Claude Code